### PR TITLE
fix: rss feed updated to sveltekit 1.0

### DIFF
--- a/src/lib/components/icons/Rss.svelte
+++ b/src/lib/components/icons/Rss.svelte
@@ -8,7 +8,7 @@
   xmlns="http://www.w3.org/2000/svg"
 >
   <title id="rss-icon-title">Rss feed</title>
-  <desc id="rss-icon-desc">Ress feed icon</desc>
+  <desc id="rss-icon-desc">Rss feed icon</desc>
   <path
     d="M12 19C12 14.8 9.2 12 5 12"
     stroke="currentColor"

--- a/src/routes/rss.xml/+server.js
+++ b/src/routes/rss.xml/+server.js
@@ -4,16 +4,13 @@ export const GET = async () => {
   const posts = await getPosts();
   const body = xml(posts);
 
-  const headers = {
-    "Cache-Control": "max-age=0, s-maxage=3600",
-    "Content-Type": "application/xml"
+  const options = {
+    headers: {
+      "Cache-Control": "max-age=0, s-maxage=3600",
+      "Content-Type": "application/xml"
+    }
   };
-  return new Response(
-    JSON.stringify({
-      headers,
-      body
-    })
-  );
+  return new Response(body, options);
 };
 
 const xml = (


### PR DESCRIPTION
fix for RSS feed not working after updating to SvelteKit 1.0